### PR TITLE
Implement XingApi::Response

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,3 +11,6 @@ Documentation:
   Enabled: false
 FrozenStringLiteralComment:
   Enabled: false
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/*'

--- a/lib/xing_api.rb
+++ b/lib/xing_api.rb
@@ -3,6 +3,7 @@ require 'oauth/signature/plaintext'
 require 'json'
 
 require 'xing_api/response_handler'
+require 'xing_api/response'
 require 'xing_api/client'
 require 'xing_api/base'
 require 'xing_api/error'

--- a/lib/xing_api/response.rb
+++ b/lib/xing_api/response.rb
@@ -1,0 +1,20 @@
+require 'delegate'
+
+module XingApi
+  class Response < SimpleDelegator
+    attr_reader :headers
+
+    def initialize(body, headers)
+      @headers = headers
+
+      body =
+        begin
+          JSON.parse(body, symbolize_names: true)
+        rescue JSON::ParserError
+          {}
+        end
+
+      super(body)
+    end
+  end
+end

--- a/lib/xing_api/response_handler.rb
+++ b/lib/xing_api/response_handler.rb
@@ -20,9 +20,10 @@ module XingApi
         raise_failed_response!(response)
       end
 
-      JSON.parse(response.body.to_s, symbolize_names: true)
-    rescue JSON::ParserError
-      {}
+      Response.new(
+        response.body.to_s,
+        response.to_hash
+      )
     end
 
     private

--- a/spec/lib/xing_api/client_spec.rb
+++ b/spec/lib/xing_api/client_spec.rb
@@ -48,8 +48,8 @@ describe XingApi::Client do
   describe '#request' do
     subject { described_class.new }
 
-    def set_expectaction(verb, url, body = '{}')
-      response_stub = stub(code: 200, body: body)
+    def set_expectaction(verb, url, body = '{}', headers = {})
+      response_stub = stub(code: 200, body: body, to_hash: headers)
       token_stub = mock do
         expects(:request).with(verb, url).returns(response_stub)
       end
@@ -77,7 +77,7 @@ describe XingApi::Client do
 
   describe '#request_with_body' do
     subject { described_class.new }
-    let(:response) { stub(code: 200, body: '{ "some": "body" }') }
+    let(:response) { stub(code: 200, body: '{ "some": "body" }', to_hash: {}) }
     let(:token) { mock }
     let(:params) { { some: 'params' } }
     before { subject.stubs(:access_token).returns(token) }

--- a/spec/lib/xing_api/response_handler_spec.rb
+++ b/spec/lib/xing_api/response_handler_spec.rb
@@ -10,6 +10,10 @@ describe XingApi::ResponseHandler do
       expect(handle_response(200, some: 'json')).to be_eql(some: 'json')
     end
 
+    it 'returns a XingApi::Response object' do
+      expect(handle_response(201, some: 'json')).to be_a(XingApi::Response)
+    end
+
     it 'returns an empty hash for no json body response' do
       expect(handle_response(201, 'Created successfully.')).to be_eql({})
     end
@@ -71,9 +75,9 @@ describe XingApi::ResponseHandler do
 
     private
 
-    def handle_response(code, body = nil)
+    def handle_response(code, body = nil, headers = nil)
       body = body.to_json if body.is_a?(Hash)
-      handle(stub(code: code, body: body))
+      handle(stub(code: code, body: body, to_hash: headers))
     end
   end
 end

--- a/spec/lib/xing_api/response_spec.rb
+++ b/spec/lib/xing_api/response_spec.rb
@@ -1,0 +1,13 @@
+describe XingApi::Response do
+  subject { XingApi::Response.new({ some: 'json' }.to_json, location: 'somewhere') }
+
+  it 'behaves like the body hash' do
+    expect(subject[:some]).to eq('json')
+  end
+
+  describe '#headers' do
+    it 'returns the given headers' do
+      expect(subject.headers).to eq(location: 'somewhere')
+    end
+  end
+end


### PR DESCRIPTION
A `XingApi::Response` object takes the parsed response body and delegates all methods to that hash.
In addition it takes a headers argument which is accessible through the `headers` method.

This closes #15 

cc @johanness 